### PR TITLE
Store colors for modules in memory

### DIFF
--- a/bows.js
+++ b/bows.js
@@ -30,7 +30,8 @@
       noop = function() {},
       colorsSupported = ls.debugColors || checkColorSupport(),
       bows = null,
-      debugRegex = null;
+      debugRegex = null,
+      moduleColorsMap = {};
 
   debugRegex = debug && debug[0]==='/' && new RegExp(debug.substring(1,debug.length-1));
 
@@ -44,7 +45,10 @@
     if (debugRegex && !str.match(debugRegex)) return noop;
 
     if (colorsSupported) {
-      var color = yieldColor();
+      if(!moduleColorsMap[str]){
+        moduleColorsMap[str]= yieldColor();
+      }
+      var color = moduleColorsMap[str];
       msg = "%c" + msg;
       colorString = "color: hsl(" + (color) + ",99%,40%); font-weight: bold";
 


### PR DESCRIPTION
ATM whenever bows is required it generates a new color for the requiring context, regardless of module name. I added a `moduleColorsMap` to look up colors for already used modules.

E.g.:
![screen shot 2014-08-18 at 13 09 55](https://cloud.githubusercontent.com/assets/436347/3950606/5a740fde-26c8-11e4-82a3-5313f4f9a215.png)

becomes

![screen shot 2014-08-18 at 13 10 22](https://cloud.githubusercontent.com/assets/436347/3950607/6416d3dc-26c8-11e4-851c-8288d3adff9a.png)
