### PR TITLE
Allow turning off colours explicitly

### DIFF
--- a/bows.js
+++ b/bows.js
@@ -32,7 +32,7 @@
       hue = 0,
       padLength = 15,
       noop = function() {},
-      colorsSupported = ls.debugColors || checkColorSupport(),
+      colorsSupported = (ls.debugColors !== "false") && checkColorSupport(),
       bows = null,
       debugRegex = null,
       invertRegex = false,


### PR DESCRIPTION
I use WebStorm for debugging my projects and it makes a connection to my client code running in a browser, however this means that `checkColorSupport()` will return `true`, while Webstorm's console doesn't support the colouring format, i.e. the output looks like this:

```sh
%csockjs-client:u  | color: hsl(319.87577519939526,99%,40%); font-weight: bold enabled iframe-htmlfile
```

This PR allows you to turn off the colours by running `localStorage.debugColors=false`. Since all localstorage values are stored as strings it will look for a string `"false"` value.