### PR TITLE
Allow consumer to specify the color.

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,13 @@ Otherwise, download either [bows.js](https://raw.github.com/latentflip/bows/mast
   localStorage.debug = true
   //Configure the max length of module names (optional)
   bows.config({ padLength: 10 })
+  //Configure the color for a particular module (optional)
+  bows.config({
+    moduleColorsMap: {
+      'what-ever-module-name1': '#FC812E',
+      'what-ever-module-name2': 'rgba(45,120,155,0.9)'
+    }
+  })
 
   var logger1 = bows('Module 1')
   var logger2 = bows('Module 2')
@@ -128,4 +135,3 @@ npm install #install dependencies
 npm test
 npm run build.js #build dist/bows.js and dist/bows.min.js, also done by `npm test`
 ```
-

--- a/bows.js
+++ b/bows.js
@@ -18,11 +18,11 @@
     return chrome || firefoxVersion >= 31.0 || electron;
   }
 
-  var yieldColor = function() {
+  var yieldColorString = function() {
     var goldenRatio = 0.618033988749895;
     hue += goldenRatio;
     hue = hue % 1;
-    return hue * 360;
+    return "hsl(" + (hue * 360) + ",99%,40%)"
   };
 
   var inNode = typeof window === 'undefined',
@@ -79,11 +79,11 @@
     var logArgs = [logger];
     if (colorsSupported) {
       if(!moduleColorsMap[str]){
-        moduleColorsMap[str]= yieldColor();
+        moduleColorsMap[str] = yieldColorString();
       }
       var color = moduleColorsMap[str];
       msg = "%c" + msg;
-      colorString = "color: hsl(" + (color) + ",99%,40%); font-weight: bold";
+      colorString = "color: " + color + "; font-weight: bold";
 
       logArgs.push(msg, colorString);
     }else{
@@ -116,6 +116,12 @@
       separator = config.separator;
     } else if (config.separator === false || config.separator === '') {
       separator = ''
+    }
+
+    if (config.moduleColorsMap) {
+      if (typeof config.moduleColorsMap === 'object') {
+        moduleColorsMap = config.moduleColorsMap;
+      }
     }
   };
 

--- a/test/custom-color.html
+++ b/test/custom-color.html
@@ -1,0 +1,48 @@
+<script type="text/javascript" src='./helpers/function.bind.js'></script>
+
+<script>
+  localStorage.debug = true;
+  localStorage.debugColors = true;
+</script>
+
+<script src="../dist/bows.js"></script>
+
+<script>
+  var mainLog, mainLog2;
+
+  bows.config({
+    moduleColorsMap: {
+      'mainLog': '#FC812E'
+    }
+  });
+
+  window.expectedLogs = [
+    'mainLog          | foo'
+  ];
+
+  window.onload = function () {
+    //Okay this is gonna get weird, because my test runner is funky
+
+    mainLog = window.bows('mainLog');
+
+    mainLog('foo');
+  }
+
+  window.customTests = function (actualLogs) {
+    var results = [];
+
+    var getColor = function (log) {
+      var match = log.match(/#\w{6}/);
+      if (!match) {
+        return undefined;
+      }
+      return match[0];
+    };
+
+
+    var colors = actualLogs.map(getColor);
+    results.push([ colors[0] === "#FC812E", "Logger printed the supplied color"]);
+
+    return results;
+  }
+</script>

--- a/test/index.js
+++ b/test/index.js
@@ -11,7 +11,8 @@ var scripts = [
     'test/no-separator.html',
     'test/padLength.html',
     'test/no-padding.html',
-    'test/args.html'
+    'test/args.html',
+    'test/custom-color.html',
 ];
 
 function runNextScript () {


### PR DESCRIPTION
This PR enables bows to accept the user-custom-module-specific color.

**Summarize of changes**

- Added new configuration `config. moduleColorsMap`.
- Modified `colorString` to accept other color options (not just HSL).
- Renamed `yieldColor` function to `yieldColorString` and changed it to return the HSL color string base on the original version.
- Added a corresponding test.
- Update readme to show how to use the option.
